### PR TITLE
Add save and loading flags to each rooms data

### DIFF
--- a/data/rooms/alchemy-laboratory/Bat Card Room.yaml
+++ b/data/rooms/alchemy-laboratory/Bat Card Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Bat Card Room.yaml
+++ b/data/rooms/alchemy-laboratory/Bat Card Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Bloody Zombie Hallway.yaml
+++ b/data/rooms/alchemy-laboratory/Bloody Zombie Hallway.yaml
@@ -10,8 +10,8 @@ Total Cells: 4
 Empty Cells: {}
 Entities:
     - Bloody Zombie
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Bloody Zombie Hallway.yaml
+++ b/data/rooms/alchemy-laboratory/Bloody Zombie Hallway.yaml
@@ -10,6 +10,8 @@ Total Cells: 4
 Empty Cells: {}
 Entities:
     - Bloody Zombie
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Blue Door Hallway.yaml
+++ b/data/rooms/alchemy-laboratory/Blue Door Hallway.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Blue Door Hallway.yaml
+++ b/data/rooms/alchemy-laboratory/Blue Door Hallway.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Box Puzzle Room.yaml
+++ b/data/rooms/alchemy-laboratory/Box Puzzle Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 4
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Box Puzzle Room.yaml
+++ b/data/rooms/alchemy-laboratory/Box Puzzle Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 4
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Cannon Room.yaml
+++ b/data/rooms/alchemy-laboratory/Cannon Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Cannon Room.yaml
+++ b/data/rooms/alchemy-laboratory/Cannon Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Cloth Cape Room.yaml
+++ b/data/rooms/alchemy-laboratory/Cloth Cape Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Cloth Cape Room.yaml
+++ b/data/rooms/alchemy-laboratory/Cloth Cape Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Corridor to Elevator.yaml
+++ b/data/rooms/alchemy-laboratory/Corridor to Elevator.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Corridor to Elevator.yaml
+++ b/data/rooms/alchemy-laboratory/Corridor to Elevator.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Elevator Shaft.yaml
+++ b/data/rooms/alchemy-laboratory/Elevator Shaft.yaml
@@ -9,8 +9,8 @@ Rows: 7
 Total Cells: 7
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Elevator Shaft.yaml
+++ b/data/rooms/alchemy-laboratory/Elevator Shaft.yaml
@@ -9,6 +9,8 @@ Rows: 7
 Total Cells: 7
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Empty Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Empty Zig Zag Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Empty Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Empty Zig Zag Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Exit to Marble Gallery.yaml
+++ b/data/rooms/alchemy-laboratory/Exit to Marble Gallery.yaml
@@ -9,8 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Exit to Marble Gallery.yaml
+++ b/data/rooms/alchemy-laboratory/Exit to Marble Gallery.yaml
@@ -9,6 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Exit to Royal Chapel.yaml
+++ b/data/rooms/alchemy-laboratory/Exit to Royal Chapel.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Red Door

--- a/data/rooms/alchemy-laboratory/Exit to Royal Chapel.yaml
+++ b/data/rooms/alchemy-laboratory/Exit to Royal Chapel.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Red Door

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter A.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter A.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter A.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter A.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter B.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter B.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter B.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter B.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter C.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter C.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Fake Room With Teleporter C.yaml
+++ b/data/rooms/alchemy-laboratory/Fake Room With Teleporter C.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Glass Vats.yaml
+++ b/data/rooms/alchemy-laboratory/Glass Vats.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Glass Vats.yaml
+++ b/data/rooms/alchemy-laboratory/Glass Vats.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Heart Max-Up Room.yaml
+++ b/data/rooms/alchemy-laboratory/Heart Max-Up Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Heart Max-Up Room.yaml
+++ b/data/rooms/alchemy-laboratory/Heart Max-Up Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room A.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room A.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room A.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room A.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Right
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room B.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room B.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room B.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room B.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Left
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room C.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room C.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Loading Room C.yaml
+++ b/data/rooms/alchemy-laboratory/Loading Room C.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Right
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Red Skeleton Lift Room.yaml
+++ b/data/rooms/alchemy-laboratory/Red Skeleton Lift Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Sections:
     - Ground
     - Alcove

--- a/data/rooms/alchemy-laboratory/Red Skeleton Lift Room.yaml
+++ b/data/rooms/alchemy-laboratory/Red Skeleton Lift Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Sections:
     - Ground
     - Alcove

--- a/data/rooms/alchemy-laboratory/Save Room A.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room A.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Right Opening
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Save Room A.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room A.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Save Room B.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room B.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Save Room B.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room B.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Left Opening
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Save Room C.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room C.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Save Room C.yaml
+++ b/data/rooms/alchemy-laboratory/Save Room C.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Right Opening
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Secret Life Max-Up Room.yaml
+++ b/data/rooms/alchemy-laboratory/Secret Life Max-Up Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Secret Life Max-Up Room.yaml
+++ b/data/rooms/alchemy-laboratory/Secret Life Max-Up Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Short Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Short Zig Zag Room.yaml
@@ -10,8 +10,8 @@ Total Cells: 2
 Empty Cells: {}
 Entities:
     - Bone Scimitar
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Short Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Short Zig Zag Room.yaml
@@ -10,6 +10,8 @@ Total Cells: 2
 Empty Cells: {}
 Entities:
     - Bone Scimitar
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Skill of Wolf Room.yaml
+++ b/data/rooms/alchemy-laboratory/Skill of Wolf Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Skill of Wolf Room.yaml
+++ b/data/rooms/alchemy-laboratory/Skill of Wolf Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Slogra and Gaibon Boss Room.yaml
+++ b/data/rooms/alchemy-laboratory/Slogra and Gaibon Boss Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 8
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Slogra and Gaibon Boss Room.yaml
+++ b/data/rooms/alchemy-laboratory/Slogra and Gaibon Boss Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 8
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Sunglasses Room.yaml
+++ b/data/rooms/alchemy-laboratory/Sunglasses Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Sunglasses Room.yaml
+++ b/data/rooms/alchemy-laboratory/Sunglasses Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Tall Spittlebone Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tall Spittlebone Room.yaml
@@ -10,6 +10,8 @@ Total Cells: 5
 Empty Cells: {}
 Entities:
     - Spittlebone
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Tall Spittlebone Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tall Spittlebone Room.yaml
@@ -10,8 +10,8 @@ Total Cells: 5
 Empty Cells: {}
 Entities:
     - Spittlebone
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Tall Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tall Zig Zag Room.yaml
@@ -9,6 +9,8 @@ Rows: 3
 Total Cells: 3
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower Node:
         Type: Secret Passage

--- a/data/rooms/alchemy-laboratory/Tall Zig Zag Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tall Zig Zag Room.yaml
@@ -9,8 +9,8 @@ Rows: 3
 Total Cells: 3
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower Node:
         Type: Secret Passage

--- a/data/rooms/alchemy-laboratory/Tetromino Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tetromino Room.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/Tetromino Room.yaml
+++ b/data/rooms/alchemy-laboratory/Tetromino Room.yaml
@@ -11,8 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Left Node:
         Type: Passage

--- a/data/rooms/alchemy-laboratory/entryway.yaml
+++ b/data/rooms/alchemy-laboratory/entryway.yaml
@@ -11,8 +11,8 @@ Empty Cells: {}
 Entities:
     - Bone Scimitar
     - Red Skeleton
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Red Door

--- a/data/rooms/alchemy-laboratory/entryway.yaml
+++ b/data/rooms/alchemy-laboratory/entryway.yaml
@@ -11,6 +11,8 @@ Empty Cells: {}
 Entities:
     - Bone Scimitar
     - Red Skeleton
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Red Door

--- a/data/rooms/castle-entrance/After Drawbridge.yaml
+++ b/data/rooms/castle-entrance/After Drawbridge.yaml
@@ -9,8 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/After Drawbridge.yaml
+++ b/data/rooms/castle-entrance/After Drawbridge.yaml
@@ -9,6 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Lower-Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Entrance.yaml
+++ b/data/rooms/castle-entrance/Attic Entrance.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Entrance.yaml
+++ b/data/rooms/castle-entrance/Attic Entrance.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Hallway.yaml
+++ b/data/rooms/castle-entrance/Attic Hallway.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 4
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Hallway.yaml
+++ b/data/rooms/castle-entrance/Attic Hallway.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 4
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Staircase.yaml
+++ b/data/rooms/castle-entrance/Attic Staircase.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Attic Staircase.yaml
+++ b/data/rooms/castle-entrance/Attic Staircase.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Cube of Zoe Room.yaml
+++ b/data/rooms/castle-entrance/Cube of Zoe Room.yaml
@@ -9,8 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Red Door

--- a/data/rooms/castle-entrance/Cube of Zoe Room.yaml
+++ b/data/rooms/castle-entrance/Cube of Zoe Room.yaml
@@ -9,6 +9,8 @@ Rows: 3
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Red Door

--- a/data/rooms/castle-entrance/Drop Under Portcullis.yaml
+++ b/data/rooms/castle-entrance/Drop Under Portcullis.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Drop Under Portcullis.yaml
+++ b/data/rooms/castle-entrance/Drop Under Portcullis.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter A.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter A.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter A.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter A.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter B.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter B.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter B.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter B.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter C.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter C.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter C.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter C.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter D.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter D.yaml
@@ -11,8 +11,7 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
-Scroll Mode:
-Type: Fake
+Flags:
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Fake Room With Teleporter D.yaml
+++ b/data/rooms/castle-entrance/Fake Room With Teleporter D.yaml
@@ -11,6 +11,8 @@ Empty Cells:
     - Row: 0
       Column: 0
 Entities:
+Scroll Mode:
+Type: Fake
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Forest Cutscene.yaml
+++ b/data/rooms/castle-entrance/Forest Cutscene.yaml
@@ -9,7 +9,7 @@ Rows: 1
 Total Cells: 18
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Forest Cutscene.yaml
+++ b/data/rooms/castle-entrance/Forest Cutscene.yaml
@@ -9,5 +9,7 @@ Rows: 1
 Total Cells: 18
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Gargoyle Room.yaml
+++ b/data/rooms/castle-entrance/Gargoyle Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Gargoyle Room.yaml
+++ b/data/rooms/castle-entrance/Gargoyle Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Heart Max-Up Room.yaml
+++ b/data/rooms/castle-entrance/Heart Max-Up Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Heart Max-Up Room.yaml
+++ b/data/rooms/castle-entrance/Heart Max-Up Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Holy Mail Room.yaml
+++ b/data/rooms/castle-entrance/Holy Mail Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Holy Mail Room.yaml
+++ b/data/rooms/castle-entrance/Holy Mail Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Jewel Sword Room.yaml
+++ b/data/rooms/castle-entrance/Jewel Sword Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Jewel Sword Room.yaml
+++ b/data/rooms/castle-entrance/Jewel Sword Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Life Max-Up Room.yaml
+++ b/data/rooms/castle-entrance/Life Max-Up Room.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Life Max-Up Room.yaml
+++ b/data/rooms/castle-entrance/Life Max-Up Room.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room A.yaml
+++ b/data/rooms/castle-entrance/Loading Room A.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room A.yaml
+++ b/data/rooms/castle-entrance/Loading Room A.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Right
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room B.yaml
+++ b/data/rooms/castle-entrance/Loading Room B.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room B.yaml
+++ b/data/rooms/castle-entrance/Loading Room B.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Left
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room C.yaml
+++ b/data/rooms/castle-entrance/Loading Room C.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room C.yaml
+++ b/data/rooms/castle-entrance/Loading Room C.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Left
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room D.yaml
+++ b/data/rooms/castle-entrance/Loading Room D.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Loading
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Loading Room D.yaml
+++ b/data/rooms/castle-entrance/Loading Room D.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Loading
+Flags:
+    - Load On Right
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Meeting Room With Death.yaml
+++ b/data/rooms/castle-entrance/Meeting Room With Death.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Meeting Room With Death.yaml
+++ b/data/rooms/castle-entrance/Meeting Room With Death.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 2
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Merman Room.yaml
+++ b/data/rooms/castle-entrance/Merman Room.yaml
@@ -9,6 +9,8 @@ Rows: 2
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Merman Room.yaml
+++ b/data/rooms/castle-entrance/Merman Room.yaml
@@ -9,8 +9,8 @@ Rows: 2
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room A.yaml
+++ b/data/rooms/castle-entrance/Save Room A.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room A.yaml
+++ b/data/rooms/castle-entrance/Save Room A.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Right Opening
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room B.yaml
+++ b/data/rooms/castle-entrance/Save Room B.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Left Opening
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room B.yaml
+++ b/data/rooms/castle-entrance/Save Room B.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room C.yaml
+++ b/data/rooms/castle-entrance/Save Room C.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Save
+Flags:
+    - Save With Left Opening
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Save Room C.yaml
+++ b/data/rooms/castle-entrance/Save Room C.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Save
 Node Sections:
     Right Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Shortcut to Underground Caverns.yaml
+++ b/data/rooms/castle-entrance/Shortcut to Underground Caverns.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Shortcut to Underground Caverns.yaml
+++ b/data/rooms/castle-entrance/Shortcut to Underground Caverns.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Shortcut to Warp.yaml
+++ b/data/rooms/castle-entrance/Shortcut to Warp.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Red Door

--- a/data/rooms/castle-entrance/Shortcut to Warp.yaml
+++ b/data/rooms/castle-entrance/Shortcut to Warp.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Red Door

--- a/data/rooms/castle-entrance/Stairwell After Death.yaml
+++ b/data/rooms/castle-entrance/Stairwell After Death.yaml
@@ -9,6 +9,8 @@ Rows: 3
 Total Cells: 3
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Stairwell After Death.yaml
+++ b/data/rooms/castle-entrance/Stairwell After Death.yaml
@@ -9,8 +9,8 @@ Rows: 3
 Total Cells: 3
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Upper-Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Unknown 19.yaml
+++ b/data/rooms/castle-entrance/Unknown 19.yaml
@@ -9,5 +9,7 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 0
+Type: Special
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Unknown 19.yaml
+++ b/data/rooms/castle-entrance/Unknown 19.yaml
@@ -9,7 +9,7 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 0
-Type: Special
+Flags:
+    - Special Type 1
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Unknown 20.yaml
+++ b/data/rooms/castle-entrance/Unknown 20.yaml
@@ -9,7 +9,7 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
-Scroll Mode: 18
-Type: Special
+Flags:
+    - Special Type 2
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Unknown 20.yaml
+++ b/data/rooms/castle-entrance/Unknown 20.yaml
@@ -9,5 +9,7 @@ Rows: 1
 Total Cells: 1
 Empty Cells: {}
 Entities:
+Scroll Mode: 18
+Type: Special
 Node Sections: {}
 Triggers:

--- a/data/rooms/castle-entrance/Warg Hallway.yaml
+++ b/data/rooms/castle-entrance/Warg Hallway.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 6
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Warg Hallway.yaml
+++ b/data/rooms/castle-entrance/Warg Hallway.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 6
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Zombie Hallway.yaml
+++ b/data/rooms/castle-entrance/Zombie Hallway.yaml
@@ -9,8 +9,8 @@ Rows: 1
 Total Cells: 7
 Empty Cells: {}
 Entities:
-Scroll Mode: 1
-Type: Normal
+Flags:
+    - Scroll Type 1
 Node Sections:
     Left Node:
         Type: Passage

--- a/data/rooms/castle-entrance/Zombie Hallway.yaml
+++ b/data/rooms/castle-entrance/Zombie Hallway.yaml
@@ -9,6 +9,8 @@ Rows: 1
 Total Cells: 7
 Empty Cells: {}
 Entities:
+Scroll Mode: 1
+Type: Normal
 Node Sections:
     Left Node:
         Type: Passage

--- a/roomrando/patcher.py
+++ b/roomrando/patcher.py
@@ -92,28 +92,10 @@ def get_room_rando_ppf(logic, changes):
             if 'Secret' not in node['Type']:
                 exit = (node['Row'], node['Column'], node['Edge'])
                 exits.append(exit)
-        first_packed_bytes = {
-            'Castle Entrance, Unknown 19': 0x80,
-            'Castle Entrance, Unknown 20': 0x92,
-            'Castle Entrance, Loading Room A': 0x41,
-            'Castle Entrance, Loading Room B': 0x40,
-            'Castle Entrance, Loading Room C': 0x40,
-            'Castle Entrance, Loading Room D': 0x41,
-            'Castle Entrance, Save Room A': 0x22,
-            'Castle Entrance, Save Room B': 0x20,
-            'Castle Entrance, Save Room C': 0x20,
-            'Alchemy Laboratory, Loading Room A': 0x41,
-            'Alchemy Laboratory, Loading Room B': 0x40,
-            'Alchemy Laboratory, Loading Room C': 0x41,
-            'Alchemy Laboratory, Save Room A': 0x20,
-            'Alchemy Laboratory, Save Room B': 0x22,
-            'Alchemy Laboratory, Save Room C': 0x22,
-        }
-        first_packed_byte = 0x01
-        if room_name in first_packed_bytes:
-            first_packed_byte = first_packed_bytes[room_name]
         room = roomrando.Room(
             changes['Rooms'][room_name]['Index'],
+            logic['Rooms'][room_name]['Type'],
+            logic['Rooms'][room_name]['Scroll Mode'],
             (
                 changes['Rooms'][room_name]['Top'],
                 changes['Rooms'][room_name]['Left'],
@@ -121,13 +103,12 @@ def get_room_rando_ppf(logic, changes):
                 logic['Rooms'][room_name]['Columns'],
             ),
             exits,
-            first_packed_byte,
         )
         result.patch_room_data(
             room,
             addresses[('Room Data', logic['Rooms'][room_name]['Stage'])]
         )
-        if 'Fake Room' not in room_name:
+        if room.room_type != 'Fake':
             result.patch_packed_room_data(
                 room,
                 addresses[('Packed Room Data', room_name)]

--- a/roomrando/patcher.py
+++ b/roomrando/patcher.py
@@ -92,10 +92,11 @@ def get_room_rando_ppf(logic, changes):
             if 'Secret' not in node['Type']:
                 exit = (node['Row'], node['Column'], node['Edge'])
                 exits.append(exit)
+        flags = set()
+        if logic['Rooms'][room_name]['Flags'] is not None:
+            flags = set(logic['Rooms'][room_name]['Flags'])
         room = roomrando.Room(
             changes['Rooms'][room_name]['Index'],
-            logic['Rooms'][room_name]['Type'],
-            logic['Rooms'][room_name]['Scroll Mode'],
             (
                 changes['Rooms'][room_name]['Top'],
                 changes['Rooms'][room_name]['Left'],
@@ -103,12 +104,13 @@ def get_room_rando_ppf(logic, changes):
                 logic['Rooms'][room_name]['Columns'],
             ),
             exits,
+            flags,
         )
         result.patch_room_data(
             room,
             addresses[('Room Data', logic['Rooms'][room_name]['Stage'])]
         )
-        if room.room_type != 'Fake':
+        if len(room.flags) > 0:
             result.patch_packed_room_data(
                 room,
                 addresses[('Packed Room Data', room_name)]

--- a/roomrando/roomrando.py
+++ b/roomrando/roomrando.py
@@ -45,15 +45,14 @@ class Address:
         return result
 
 class Room:
-    def __init__(self, room_index: int, room_type: str, scroll_mode: int, box: tuple[int], exits: list[tuple]):
+    def __init__(self, room_index: int, box: tuple[int], exits: list[tuple], flags: set[str]):
         self.room_index = room_index
-        self.room_type = room_type
-        self.scroll_mode = scroll_mode
         self.top = box[0]
         self.left = box[1]
         self.height = box[2]
         self.width = box[3]
         self.exits = exits
+        self.flags = flags
 
 class Teleporter:
     def __init__(self, teleporter_index: int, x: int, y: int, room_index: int, current_stage_id: int, next_stage_id: int):
@@ -193,17 +192,21 @@ class PPF:
         self.write_u64(address.to_disc_address())
         size = 4
         self.write_byte(size)
-        first_packed_byte = room.scroll_mode
+        flags_byte = 0x00
         flags = {
-            'Special': 0x80,
-            'Loading': 0x40,
-            'Save': 0x20,
-            'Normal': 0x00,
-            'Fake': 0x00,
+            'Load On Left': 0x40,
+            'Load On Right': 0x41,
+            'Save With Left Opening': 0x20,
+            'Save With Right Opening': 0x22,
+            'Scroll Type 1': 0x01,
+            'Special Type 1': 0x80,
+            'Special Type 2': 0x92,
         }
-        first_packed_byte |= flags[room.room_type]
+        for flag_name in room.flags:
+            if flag_name in flags:
+                flags_byte |= flags[flag_name]
         data = [
-            first_packed_byte,
+            flags_byte,
             0x3F & (room.top + room.height - 1), # bottom
             0x3F & (room.left + room.width - 1), # right
             0x3F & (room.top),

--- a/roomrando/roomrando.py
+++ b/roomrando/roomrando.py
@@ -45,14 +45,15 @@ class Address:
         return result
 
 class Room:
-    def __init__(self, room_index: int, box: tuple[int], exits: list[tuple], first_packed_byte: int=0x01):
+    def __init__(self, room_index: int, room_type: str, scroll_mode: int, box: tuple[int], exits: list[tuple]):
         self.room_index = room_index
+        self.room_type = room_type
+        self.scroll_mode = scroll_mode
         self.top = box[0]
         self.left = box[1]
         self.height = box[2]
         self.width = box[3]
         self.exits = exits
-        self.first_packed_byte = first_packed_byte
 
 class Teleporter:
     def __init__(self, teleporter_index: int, x: int, y: int, room_index: int, current_stage_id: int, next_stage_id: int):
@@ -192,8 +193,17 @@ class PPF:
         self.write_u64(address.to_disc_address())
         size = 4
         self.write_byte(size)
+        first_packed_byte = room.scroll_mode
+        flags = {
+            'Special': 0x80,
+            'Loading': 0x40,
+            'Save': 0x20,
+            'Normal': 0x00,
+            'Fake': 0x00,
+        }
+        first_packed_byte |= flags[room.room_type]
         data = [
-            room.first_packed_byte,
+            first_packed_byte,
             0x3F & (room.top + room.height - 1), # bottom
             0x3F & (room.left + room.width - 1), # right
             0x3F & (room.top),

--- a/roomrando/shuffler.py
+++ b/roomrando/shuffler.py
@@ -219,8 +219,6 @@ class RoomSet:
     def remove_room(self, room_name):
         self.rooms.pop(room_name, None)
 
-(a, b) = (24, 24)
-
 stages = {
     'Castle Entrance': [
         {
@@ -402,7 +400,7 @@ if __name__ == '__main__':
             current_seed = rng.randint(0, 2 ** 64)
             rng = random.Random(current_seed)
         (top, left, bottom, right) = alchemy_laboratory.get_bounds()
-        castle.add_roomset(alchemy_laboratory, 48 - top, 16 - left)
+        castle.add_roomset(alchemy_laboratory, 46 - top, 14 - left)
         file_name = 'build/RoomChanges.yaml'
         with open(file_name, 'w') as open_file:
             changes = castle.get_changes()


### PR DESCRIPTION
Resolves #1

The following flags are needed to process packed room data for rooms:
- Scroll Type 1 (The standard scrolling foreground used in most rooms)
- Load On Left (Loading Room where the next stage is reached on the left-hand side)
- Load On Right (Loading Room where the next stage is reached on the right-hand side)
- Save With Left Opening (A Save Room with an opening on the left-hand side)
- Save With Right Opening (A Save Room with an opening on the right-hand side)
- Special Type 1 (Unknown, used during the Forest Intro cutscene)
- Special Type 2 (Unknown, used during the Forest Intro cutscene)

At the moment, the Fake Rooms used after each Loading Room have no flags, and the patcher checks for the absence of any flags to identify these rooms. This may need to change later on if non-fake rooms with no flags are encountered.